### PR TITLE
Support google-cloud-tasks 2.0 or later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+## 0.2.0
+
+This version depends on google-cloud-tasks 2.0 or later. Since google-cloud-tasks 2.0 has API changes, upgrading to this version may affect to existing adapter initialization code. If you are initializing Google::Cloud::Tasks client manually, you will have to change `Google::Cloud::Tasks.new` to `Google::Cloud::Tasks.cloud_tasks` as follows:
+
+from:
+
+    Rails.application.config.active_job.queue_adapter = ActiveJob::GoogleCloudTasks::HTTP::Adapter.new(
+      client: Google::Cloud::Tasks.new(version: :v2beta3),
+      # ...
+    )
+
+to:
+
+    Rails.application.config.active_job.queue_adapter = ActiveJob::GoogleCloudTasks::HTTP::Adapter.new(
+      client: Google::Cloud::Tasks.cloud_tasks(version: :v2beta3),
+      # ...
+    )
+
+For more information, see this migration guide: https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-tasks/MIGRATING.md
+
+## 0.1.0
+
+:tada:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Rails.application.config.active_job.queue_adapter = ActiveJob::GoogleCloudTasks:
   project: 'a-gcp-project-name',
   location: 'asia-northeast1',
   url: 'https://an-endpoint-to-perform-jobs.a.run.app/_jobs',
-  client: Google::Cloud::Tasks.new(version: :v2beta3), # optional
+  client: Google::Cloud::Tasks.cloud_tasks(version: :v2beta3), # optional
   task_options: { # optional
     oidc_token: {
       service_account_email: 'cloudrun-invoker@a-gcp-project-name.iam.gserviceaccount.com'
@@ -75,7 +75,7 @@ unless ARGV.include?("assets:precompile") # prevents running on assets:precompil
     project: 'my-project',
     location: 'europe-west2',
     url: 'https://www.example.com/jobs',
-    client: Google::Cloud::Tasks.new(
+    client: Google::Cloud::Tasks.cloud_tasks(
       version: :v2beta3,
       credentials: JSON.parse(ENV["GOOGLE_CLOUD_PRODUCTION_KEYFILE"]) # this will cause an error if the environment variable does not exist
     )

--- a/activejob-google_cloud_tasks-http.gemspec
+++ b/activejob-google_cloud_tasks-http.gemspec
@@ -17,14 +17,14 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|example-app)/}) }
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activejob"
-  spec.add_runtime_dependency "google-cloud-tasks"
+  spec.add_runtime_dependency "google-cloud-tasks", ">= 2.0.0"
   spec.add_runtime_dependency "rack"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/active_job/google_cloud_tasks/http/adapter.rb
+++ b/lib/active_job/google_cloud_tasks/http/adapter.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'google/cloud/tasks'
+require 'gapic/grpc' # to use Google::Protobuf::Timestamp which is used by Google::Cloud::Tasks::Vxx
 
 module ActiveJob
   module GoogleCloudTasks
@@ -14,10 +15,10 @@ module ActiveJob
         end
 
         def enqueue(job, attributes = {})
-          path = client.queue_path(@project, @location, job.queue_name)
+          path = client.queue_path(project: @project, location: @location, queue: job.queue_name)
           task = build_task(job, attributes)
 
-          client.create_task path, task
+          client.create_task parent: path, task: task
         end
 
         def enqueue_at(job, scheduled_at)
@@ -27,7 +28,7 @@ module ActiveJob
         private
 
         def client
-          @client ||= Google::Cloud::Tasks.new(version: :v2beta3)
+          @client ||= Google::Cloud::Tasks.cloud_tasks(version: :v2beta3)
         end
 
         def build_task(job, attributes)

--- a/lib/active_job/google_cloud_tasks/http/version.rb
+++ b/lib/active_job/google_cloud_tasks/http/version.rb
@@ -1,7 +1,7 @@
 module ActiveJob
   module GoogleCloudTasks
     module HTTP
-      VERSION = "0.1.3"
+      VERSION = "0.2.0"
     end
   end
 end

--- a/spec/active_job/google_cloud_tasks/http_spec.rb
+++ b/spec/active_job/google_cloud_tasks/http_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe ActiveJob::GoogleCloudTasks::HTTP do
         client: client
       )
 
-      expect(client).to receive(:create_task) do |_path, task|
-        expect(task[:schedule_time]).to eq (Google::Protobuf::Timestamp.new(seconds: scheduled_at))
+      expect(client).to receive(:create_task) do |args|
+        expect(args[:task][:schedule_time]).to eq (Google::Protobuf::Timestamp.new(seconds: scheduled_at))
       end
 
       adapter.enqueue_at job, scheduled_at


### PR DESCRIPTION
Changed to use google-cloud-tasks 2.0 or later. This may affect to existing adapter initialization code. If you are initializing Google::Cloud::Tasks client manually, you will have to change `Google::Cloud::Tasks.new` to `Google::Cloud::Tasks.cloud_tasks` as follows:

from:

    Rails.application.config.active_job.queue_adapter = ActiveJob::GoogleCloudTasks::HTTP::Adapter.new(
      client: Google::Cloud::Tasks.new(version: :v2beta3),
      # ...
    )

to:

    Rails.application.config.active_job.queue_adapter = ActiveJob::GoogleCloudTasks::HTTP::Adapter.new(
      client: Google::Cloud::Tasks.cloud_tasks(version: :v2beta3),
      # ...
    )

For more information, see this migration guide: https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-tasks/MIGRATING.md

Fixes #6