### PR TITLE
Support for enqueue_after_transaction_commit setting introduced in Rails 7.2

### DIFF
--- a/lib/active_job/google_cloud_tasks/http/adapter.rb
+++ b/lib/active_job/google_cloud_tasks/http/adapter.rb
@@ -6,12 +6,18 @@ module ActiveJob
   module GoogleCloudTasks
     module HTTP
       class Adapter
-        def initialize(project:, location:, url:, task_options: {}, client: nil)
+        def initialize(project:, location:, url:, task_options: {}, client: nil, enqueue_after_transaction_commit: false)
           @project = project
           @location = location
           @url = url
           @task_options = task_options
           @client = client
+          @enqueue_after_transaction_commit = enqueue_after_transaction_commit
+        end
+
+        # Method expected in Rails 7.2 and later
+        def enqueue_after_transaction_commit?
+          @enqueue_after_transaction_commit
         end
 
         def enqueue(job, attributes = {})

--- a/lib/active_job/google_cloud_tasks/http/inline.rb
+++ b/lib/active_job/google_cloud_tasks/http/inline.rb
@@ -4,6 +4,11 @@ module ActiveJob
   module GoogleCloudTasks
     module HTTP
       module Inlining
+        # Method expected in Rails 7.2 and later
+        def enqueue_after_transaction_commit?
+          false
+        end
+
         def enqueue(job, *)
           ActiveJob::Base.execute job.serialize
         end


### PR DESCRIPTION
Fix #13

The `enqueue_after_transaction_commit` method is required starting from Rails 7.2. To maintain compatibility with both Rails 7.2 and earlier versions, the `enqueue_after_transaction_commit?` method was directly implemented instead of inheriting from [ActiveJob::QueueAdapters::AbstractAdapter](https://github.com/rails/rails/blob/a1f6a13f691e0929d40b7e1b1e0d31aa69778128/activejob/lib/active_job/queue_adapters/abstract_adapter.rb#L14-L16).

By default, `enqueue_after_transaction_commit` returns `false` in Rails.

You can set `enqueue_after_transaction_commit` to `true` when creating the adapter as shown below:

```ruby
ActiveJob::GoogleCloudTasks::HTTP::Adapter.new(
  project: 'apollo',
  location: 'asia-northeast1',
  url: 'https://example.com/_jobs',
  client: client,
  enqueue_after_transaction_commit: true,
)
```
