### PR TITLE
Stop specifying the explicit API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+Now the default Google::Cloud::Tasks client uses its default API version. Fixed #15.
+
 ## 0.2.0
 
 This version depends on google-cloud-tasks 2.0 or later. Since google-cloud-tasks 2.0 has API changes, upgrading to this version may affect to existing adapter initialization code. If you are initializing Google::Cloud::Tasks client manually, you will have to change `Google::Cloud::Tasks.new` to `Google::Cloud::Tasks.cloud_tasks` as follows:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Configure an adapter instance and pass it to Active Job:
 Rails.application.config.active_job.queue_adapter = ActiveJob::GoogleCloudTasks::HTTP::Adapter.new(
   project: 'a-gcp-project-name',
   location: 'asia-northeast1',
-  url: 'https://an-endpoint-to-perform-jobs.a.run.app/_jobs',
-  client: Google::Cloud::Tasks.cloud_tasks(version: :v2beta3), # optional
+  url: 'https://hibariya.org/',
+  client: Google::Cloud::Tasks.cloud_tasks, # optional
   task_options: { # optional
     oidc_token: {
       service_account_email: 'cloudrun-invoker@a-gcp-project-name.iam.gserviceaccount.com'
@@ -75,7 +75,7 @@ unless ARGV.include?("assets:precompile") # prevents running on assets:precompil
     project: 'my-project',
     location: 'europe-west2',
     url: 'https://www.example.com/jobs',
-    client: Google::Cloud::Tasks.cloud_tasks(version: :v2beta3) { |config|
+    client: Google::Cloud::Tasks.cloud_tasks { |config|
       # this will cause an error if the environment variable does not exist
       config.credentials = JSON.parse(ENV["GOOGLE_CLOUD_PRODUCTION_KEYFILE"])
     }

--- a/lib/active_job/google_cloud_tasks/http/adapter.rb
+++ b/lib/active_job/google_cloud_tasks/http/adapter.rb
@@ -34,7 +34,7 @@ module ActiveJob
         private
 
         def client
-          @client ||= Google::Cloud::Tasks.cloud_tasks(version: :v2beta3)
+          @client ||= Google::Cloud::Tasks.cloud_tasks
         end
 
         def build_task(job, attributes)

--- a/lib/active_job/google_cloud_tasks/http/version.rb
+++ b/lib/active_job/google_cloud_tasks/http/version.rb
@@ -1,7 +1,7 @@
 module ActiveJob
   module GoogleCloudTasks
     module HTTP
-      VERSION = "0.3.0"
+      VERSION = "0.4.0"
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/esminc/activejob-google_cloud_tasks-http/issues/15

As @koic suggested in the issue, I removed the fixed version parameter since it's doesn't make sense today and hard to maintain.

I also confirmed enqueue is working after the change by running the following code just in case:

```ruby
# The env var GOOGLE_APPLICATION_CREDENTIALS ponts the necessary keyfile
adapter = ActiveJob::GoogleCloudTasks::HTTP::Adapter.new(
  project: 'delta-petra',
  location: 'asia-northeast1',
  url: 'https://hibariya.org/', # will get 404 tho
)

class TestJob
  def serialize = {}
  def queue_name = 'test-queue'
end

adapter.enqueue(TestJob.new)
# => <Google::Cloud::Tasks::V2::Task: name: "projects/delta-petra/locations/asia-northeast1/queues/test-queue/tasks/43981710605354104261", http_request: <Google::Cloud::Tasks::V2::HttpRequest: url: "https://hibariya.org/", http_method: :POST, headers: {"User-Agent"=>"Google-Cloud-Tasks", "Content-Type"=>"application/json"}, body: "">, schedule_time: <Google::Protobuf::Timestamp: seconds: 1744329215, nanos: 673695000>, create_time: <Google::Protobuf::Timestamp: seconds: 1744329215, nanos: 0>, dispatch_deadline: <Google::Protobuf::Duration: seconds: 600, nanos: 0>, dispatch_count: 0, response_count: 0, view: :BASIC> 
```