### PR TITLE
Tweaking the CI settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,18 @@ jobs:
         ruby_image:
           - ruby:latest
           - ruby:3.3
-          - ruby:3.0
-          - ruby:2.7
-          - ruby:2.6
         bundle:
           - latest
           - activejob-7.2
-          - activejob-6.1
-          - activejob-6.0
-          - activejob-5.2
+        include:
+          - ruby_image: ruby:2.6
+            bundle: activejob-5.2
+          - ruby_image: ruby:2.6
+            bundle: activejob-6.1
+          - ruby_image: ruby:3.0
+            bundle: activejob-5.2
+          - ruby_image: ruby:3.0
+            bundle: activejob-6.1
     container:
       image: ${{ matrix.ruby_image }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,13 @@ jobs:
       matrix:
         ruby_image:
           - ruby:latest
+          - ruby:3.3
           - ruby:3.0
           - ruby:2.7
           - ruby:2.6
         bundle:
           - latest
+          - activejob-7.2
           - activejob-6.1
           - activejob-6.0
           - activejob-5.2
@@ -22,7 +24,7 @@ jobs:
       image: ${{ matrix.ruby_image }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies and run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         ruby_image:
           - ruby:latest
           - ruby:3.3
+          - ruby:3.4
         bundle:
           - latest
           - activejob-7.2

--- a/Appraisals
+++ b/Appraisals
@@ -2,6 +2,10 @@ appraise 'latest' do
   gem 'activejob'
 end
 
+appraise 'activejob-7.2' do
+  gem 'activejob', '~> 7.2.2'
+end
+
 appraise 'activejob-6.1' do
   gem 'activejob', '~> 6.1.4'
 end

--- a/Appraisals
+++ b/Appraisals
@@ -1,17 +1,16 @@
-appraise 'latest' do
-  gem 'activejob'
-end
 
-appraise 'activejob-7.2' do
-  gem 'activejob', '~> 7.2.2'
+if RUBY_VERSION >= '3.1'
+  appraise 'latest' do
+    gem 'activejob'
+  end
+
+  appraise 'activejob-7.2' do
+    gem 'activejob', '~> 7.2.2'
+  end
 end
 
 appraise 'activejob-6.1' do
   gem 'activejob', '~> 6.1.4'
-end
-
-appraise 'activejob-6.0' do
-  gem 'activejob', '~> 6.0.4'
 end
 
 appraise 'activejob-5.2' do

--- a/activejob-google_cloud_tasks-http.gemspec
+++ b/activejob-google_cloud_tasks-http.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.6.0'
+
   spec.add_runtime_dependency "activejob"
   spec.add_runtime_dependency "google-cloud-tasks", ">= 2.0.0"
   spec.add_runtime_dependency "rack"

--- a/spec/active_job/google_cloud_tasks/http_spec.rb
+++ b/spec/active_job/google_cloud_tasks/http_spec.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'active_job'
 require 'stringio'
 


### PR DESCRIPTION
- Added an explicit `require 'logger'` to fix errors ([like this](https://github.com/esminc/activejob-google_cloud_tasks-http/actions/runs/14393570765/job/40365190233?pr=18)) in some older versions of ActiveJob
- Added *a bit* older Ruby and ActiveJob to the test matrix
- Reduced the number of `ruby x active_job` combinations for too older versions
