### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.3.0
+## 0.4.0
 
-Now the default Google::Cloud::Tasks client uses its default API version. Fixed #15.
+Now the default Google::Cloud::Tasks client uses its default API version. Fixed [#15](https://github.com/esminc/activejob-google_cloud_tasks-http/issues/15).
 
 ## 0.2.0
 


### PR DESCRIPTION
The original change was [here](https://github.com/esminc/activejob-google_cloud_tasks-http/pull/17/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1), I believe you meant 0.4.0